### PR TITLE
Fix ES launch failure detailed in #1

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,5 +1,6 @@
 discovery.type: single-node
 bootstrap.memory_lock: true
+bootstrap.system_call_filter: false
 
 # ======================== Elasticsearch Configuration =========================
 #


### PR DESCRIPTION
Fixes the following error on ES startup:
```
java.lang.UnsupportedOperationException: seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed
	at org.elasticsearch.bootstrap.SystemCallFilter.linuxImpl(SystemCallFilter.java:342) ~[elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.SystemCallFilter.init(SystemCallFilter.java:617) ~[elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.JNANatives.tryInstallSystemCallFilter(JNANatives.java:260) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Natives.tryInstallSystemCallFilter(Natives.java:113) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Bootstrap.initializeNatives(Bootstrap.java:116) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:178) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:393) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:170) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:161) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:127) [elasticsearch-cli-7.9.3.jar:7.9.3]
	at org.elasticsearch.cli.Command.main(Command.java:90) [elasticsearch-cli-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:126) [elasticsearch-7.9.3.jar:7.9.3]
	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92) [elasticsearch-7.9.3.jar:7.9.3]
```